### PR TITLE
Update jekyll-theme-midnight.scss

### DIFF
--- a/_sass/jekyll-theme-midnight.scss
+++ b/_sass/jekyll-theme-midnight.scss
@@ -169,8 +169,8 @@ dt {
     max-width: 650px;
     margin: 0 auto;
     padding: 0 10px;
-    background: blue;
     margin: 6px auto;
+    display: flex;
 
     li {
       font-family: 'OpenSansLight', "Helvetica Neue", Helvetica, Arial, sans-serif;
@@ -210,6 +210,11 @@ dt {
         margin-left: 0px;
       }
 
+      nav li:nth-child(2) {
+        margin-left: auto;
+      }
+      
+      
       &.downloads {
         float: right;
         margin-left: 6px;


### PR DESCRIPTION
nav ist jetzt ein Flex Container.
Zweites li Element (also der zweite Button) sollte jetzt immer den größtmöglichen Abstand zum ersten Button haben.
Schau mal ob das klappt und ob die Buttons bei der Iphone Ansicht zu sehen sind.